### PR TITLE
Feature/leader log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "alexandria"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -3,13 +3,3 @@
 ## about
 
 raft based distributed database from scratch
-
-## todo
-
-- [ ] finish and test raft implementation
-    - [x] raft startup (follower and candidate implementation)
-    - [ ] leader node (log replication, log commit, state_machine)
-- [ ] write doc about the threading model of a peer
-- [ ] configure log level (production, debug, channel, etc)
-- [ ] store-db engine
-- [ ] review Messages struct (i guess i can remove the field "term" since every message already contains this info)

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ raft based distributed database from scratch
 - [ ] write doc about the threading model of a peer
 - [ ] configure log level (production, debug, channel, etc)
 - [ ] store-db engine
+- [ ] review Messages struct (i guess i can remove the field "term" since every message already contains this info)

--- a/README.md
+++ b/README.md
@@ -7,5 +7,8 @@ raft based distributed database from scratch
 ## todo
 
 - [ ] finish and test raft implementation
-- [ ] configure log level (productio, debug, channel, etc)
+    - [x] raft startup (follower and candidate implementation)
+    - [ ] leader node (log replication, log commit, state_machine)
+- [ ] write doc about the threading model of a peer
+- [ ] configure log level (production, debug, channel, etc)
 - [ ] store-db engine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: "3.8"
-
 services:
   peer1:
+    image: alexandria-image
     build:
       context: .
     environment:
@@ -16,8 +15,7 @@ services:
       - ./logs/peer1/:/usr/src/raft/logs/
 
   peer2:
-    build:
-      context: .
+    image: alexandria-image
     environment:
       - PEER_ADDR=192.30.0.102:8080
       - PEERS=192.30.0.101:8080,192.30.0.103:8080
@@ -30,8 +28,7 @@ services:
       - ./logs/peer2/:/usr/src/raft/logs/
 
   peer3:
-    build:
-      context: .
+    image: alexandria-image
     environment:
       - PEER_ADDR=192.30.0.103:8080
       - PEERS=192.30.0.101:8080,192.30.0.102:8080

--- a/docs/raft.txt
+++ b/docs/raft.txt
@@ -16,7 +16,7 @@ starts following the message sender node, otherwise, it just ignores the message
 
 
 === candidate role ===
-- candidate starts voting for himself (candidate.role.votes == 1)
+- candidate starts voting for himself (candidate.role.votes == 1) and incrementing the current term
 
 - candidate has an election_timeout, when this timeout reaches its limit, the candidate 
 increase his last_term (self last_term+=1) and starts a new election
@@ -31,6 +31,8 @@ increase his last_term (self last_term+=1) and starts a new election
 
 
 === leader role === 
-- the leader node, keep sending hearbeats (broadcast appendEntries messages) to keep leadering
+- the leader node, keep sending hearbeats to keep leadering
 
-- if a leader receives a ...... (write leader role behavior)
+- if a leader receives a client command, it appends its own log with this new entry, then broadcast 
+this entry for other peers, when the majority of peers has received the appendEntries, the leader 
+commits this entry, meaning that it is safe to apply the command to the state machine

--- a/docs/raft.txt
+++ b/docs/raft.txt
@@ -12,7 +12,7 @@ increases his last_term, becomes a candidate, and broadcasts a requestVote messa
 - if a follower receives an requestVote message, it compares the message term with his own last_term, if the message term is bigger, it broadcasts a vote message (voting for the sender node), and 
 starts following the message sender node, otherwise, it just ignores the message
 
-- if a follower receives an Vote message, it just ignores the message
+- if a follower receives a Vote message, it just ignores the message
 
 
 === candidate role ===
@@ -33,4 +33,4 @@ increase his last_term (self last_term+=1) and starts a new election
 === leader role === 
 - the leader node, keep sending hearbeats (broadcast appendEntries messages) to keep leadering
 
-- if a leader receives an ...... (write leader role behavior)
+- if a leader receives a ...... (write leader role behavior)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod raft;
+pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,10 +36,9 @@ async fn main() {
 
     // curl -X POST -d '(term:1, from: Peer("test"), to: Peer("test"), event: ClientRequest(command: "test"))' url
     // 
-    // TODO: create the client layer, responsible to create properly formatted messages to peers, and
+    // todo: create the client layer, responsible to create properly formatted messages to peers, and
     // redirect messages that were sent to peers that are not leaders. 
     //
     // user request/message -> raft/client -> raft/server -> peer/node
     //
-    // TODO: create the log structure to handle log appending and properly replication
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod utils;
 
 use std::env;
 use tokio::net::TcpListener;
+use raft::node::log::Log;
 use log::LevelFilter;
 use log::info;
 
@@ -24,7 +25,7 @@ async fn main() {
          vec!()
     };
 
-    let server = raft::server::Server::new(&env_addr, peers, raft::node::Log::new()).await;
+    let server = raft::server::Server::new(&env_addr, peers, Log::new()).await;
 
     let tcp_listener = match TcpListener::bind("0.0.0.0:8080").await {
         Ok(listener) => listener,

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ async fn main() {
 
     let _ = server.serve(tcp_listener).await;
 
-    // curl -X POST -d '(term:1, from: Peer("test"), to: Peer("test"), event: ClientRequest(test:1, query: Get(1)))' url
+    // curl -X POST -d '(term:1, from: Peer("test"), to: Peer("test"), event: ClientRequest(command: "test"))' url
     // 
     // TODO: create the client layer, responsible to create properly formatted messages to peers, and
     // redirect messages that were sent to peers that are not leaders. 

--- a/src/raft/client.rs
+++ b/src/raft/client.rs
@@ -8,7 +8,7 @@ pub struct Client {
 // query requests and parse to Event::ClientRequest,
 // redirect the query if the peer is not a leader, or execute if 
 // the query is not a transaction
-// TODO: implement the message routing, if the query is a transaction, redirect to leader,
+// todo: implement the message routing, if the query is a transaction, redirect to leader,
 // otherwise, run in the current node
 impl Client {
     pub async fn new(server: Server) -> Self {

--- a/src/raft/message.rs
+++ b/src/raft/message.rs
@@ -26,7 +26,6 @@ pub enum Address {
     Peer(String),
 }
 
-// todo: remove the term field (since every message already contains the current term)
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Event {
     AppendEntries { entries: Vec<Entry> },

--- a/src/raft/message.rs
+++ b/src/raft/message.rs
@@ -20,6 +20,7 @@ impl Message {
     }
 }
 
+// todo: add Client address option
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Address {
     Broadcast,

--- a/src/raft/message.rs
+++ b/src/raft/message.rs
@@ -27,15 +27,8 @@ pub enum Address {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Event {
-    AppendEntries { index: u64, term: u64 },
+    AppendEntries { term: u64, command: String },
     RequestVote { term: u64 },
     Vote { term: u64, voted_for: String },
-    ClientRequest { test: u64, query: Query }
+    ClientRequest { command: String }
 }
-
-#[derive(Debug, Serialize, Deserialize)]
-pub enum Query {
-    Get(u64)
-}
-
-

--- a/src/raft/message.rs
+++ b/src/raft/message.rs
@@ -28,10 +28,10 @@ pub enum Address {
 // todo: remove the term field (since every message already contains the current term)
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Event {
-    AppendEntries { term: u64, index: u64, entries: Vec<String> },
-    AckEntries { term: u64, index: u64 },
-    Heartbeat { term: u64 },
-    RequestVote { term: u64 },
-    Vote { term: u64, voted_for: String },
+    AppendEntries { index: u64, entries: Vec<String> },
+    AckEntries { index: u64 },
+    Heartbeat {},
+    RequestVote {},
+    Vote { voted_for: String },
     ClientRequest { command: String }
 }

--- a/src/raft/message.rs
+++ b/src/raft/message.rs
@@ -27,7 +27,7 @@ pub enum Address {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Event {
-    AppendEntries { term: u64, command: String },
+    AppendEntries { term: u64, index: u64, command: String },
     Heartbeat { term: u64 },
     RequestVote { term: u64 },
     Vote { term: u64, voted_for: String },

--- a/src/raft/message.rs
+++ b/src/raft/message.rs
@@ -29,8 +29,7 @@ pub enum Address {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Event {
-    // todo: implement with Option<Vec<Entry>>
-    AppendEntries { entries: Vec<Entry> },
+    AppendEntries { entries: Option<Vec<Entry>>, commit_index: usize },
     AckEntries { index: usize },
     RequestVote {},
     Vote { voted_for: String },

--- a/src/raft/message.rs
+++ b/src/raft/message.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use super::node::log::Entry;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Message {
     pub term: u64,
     pub from: Address,
@@ -20,13 +20,13 @@ impl Message {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Address {
     Broadcast,
     Peer(String),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Event {
     AppendEntries { entries: Vec<Entry> },
     AckEntries { index: usize },

--- a/src/raft/message.rs
+++ b/src/raft/message.rs
@@ -29,9 +29,9 @@ pub enum Address {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Event {
+    // todo: implement with Option<Vec<Entry>>
     AppendEntries { entries: Vec<Entry> },
     AckEntries { index: usize },
-    Heartbeat {},
     RequestVote {},
     Vote { voted_for: String },
     ClientRequest { command: String }

--- a/src/raft/message.rs
+++ b/src/raft/message.rs
@@ -28,6 +28,7 @@ pub enum Address {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Event {
     AppendEntries { term: u64, command: String },
+    Heartbeat { term: u64 },
     RequestVote { term: u64 },
     Vote { term: u64, voted_for: String },
     ClientRequest { command: String }

--- a/src/raft/message.rs
+++ b/src/raft/message.rs
@@ -25,6 +25,7 @@ pub enum Address {
     Peer(String),
 }
 
+// todo: remove the term field (since every message already contains the current term)
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Event {
     AppendEntries { term: u64, index: u64, entries: Vec<String> },

--- a/src/raft/message.rs
+++ b/src/raft/message.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use super::node::log::Entry;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Message {
@@ -28,8 +29,8 @@ pub enum Address {
 // todo: remove the term field (since every message already contains the current term)
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Event {
-    AppendEntries { index: u64, entries: Vec<String> },
-    AckEntries { index: u64 },
+    AppendEntries { entries: Vec<Entry> },
+    AckEntries { index: usize },
     Heartbeat {},
     RequestVote {},
     Vote { voted_for: String },

--- a/src/raft/message.rs
+++ b/src/raft/message.rs
@@ -27,7 +27,8 @@ pub enum Address {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Event {
-    AppendEntries { term: u64, index: u64, command: String },
+    AppendEntries { term: u64, index: u64, entries: Vec<String> },
+    AckEntries { term: u64, index: u64 },
     Heartbeat { term: u64 },
     RequestVote { term: u64 },
     Vote { term: u64, voted_for: String },

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -1,4 +1,4 @@
-mod message;
+pub mod message;
 mod state_machine;
 
 pub mod node;

--- a/src/raft/node/candidate.rs
+++ b/src/raft/node/candidate.rs
@@ -29,7 +29,7 @@ impl Candidate {
 impl Role<Candidate> {
     pub fn step(mut self, msg: Message) -> Result<Node, &'static str> {
         match msg.event {
-            Event::AppendEntries { term, command: _ } => {
+            Event::AppendEntries { term, command: _, index: _ } => {
                 info!(target: "raft_candidate", 
                       "candidate is receiving an appendEntries, checking message term...");
                 if term >= self.log.last_term {
@@ -219,7 +219,7 @@ mod tests {
         let (candidate, _, _) = setup();
 
         let msg = Message {
-            event: Event::AppendEntries { term: 2, command: String::from("") },
+            event: Event::AppendEntries { term: 2, index: 1, command: String::from("") },
             term: 2,
             to: Address::Broadcast,
             from: Address::Peer("c".into()),

--- a/src/raft/node/candidate.rs
+++ b/src/raft/node/candidate.rs
@@ -29,7 +29,7 @@ impl Candidate {
 impl Role<Candidate> {
     pub fn step(mut self, msg: Message) -> Result<Node, &'static str> {
         match msg.event {
-            Event::AppendEntries { term, command: _, index: _ } => {
+            Event::AppendEntries { term, entries: _, index: _ } => {
                 info!(target: "raft_candidate", 
                       "candidate is receiving an appendEntries, checking message term...");
                 if term >= self.log.last_term {
@@ -219,7 +219,7 @@ mod tests {
         let (candidate, _, _) = setup();
 
         let msg = Message {
-            event: Event::AppendEntries { term: 2, index: 1, command: String::from("") },
+            event: Event::AppendEntries { term: 2, index: 1, entries: vec!(String::from("")) },
             term: 2,
             to: Address::Broadcast,
             from: Address::Peer("c".into()),

--- a/src/raft/node/candidate.rs
+++ b/src/raft/node/candidate.rs
@@ -101,8 +101,7 @@ impl Role<Candidate> {
                     info!(target: "raft_candidate", "candidate received a vote");
                     self.role.votes += 1;
 
-                    // todo: check this rule (i guess it can become leader with majority of votes
-                    // instead of all votes)
+                    // todo: check this rule (i guess it can become leader with majority of votes instead of all votes)
                     if self.role.votes >= self.peers.len() as u64 {
                         let peers = self.peers.clone();
                         Ok(self

--- a/src/raft/node/candidate.rs
+++ b/src/raft/node/candidate.rs
@@ -101,6 +101,8 @@ impl Role<Candidate> {
                     info!(target: "raft_candidate", "candidate received a vote");
                     self.role.votes += 1;
 
+                    // todo: check this rule (i guess it can become leader with majority of votes
+                    // instead of all votes)
                     if self.role.votes >= self.peers.len() as u64 {
                         let peers = self.peers.clone();
                         Ok(self

--- a/src/raft/node/candidate.rs
+++ b/src/raft/node/candidate.rs
@@ -29,7 +29,7 @@ impl Candidate {
 impl Role<Candidate> {
     pub fn step(mut self, msg: Message) -> Result<Node, &'static str> {
         match msg.event {
-            Event::AppendEntries { index: _, term } => {
+            Event::AppendEntries { term, command: _ } => {
                 info!(target: "raft_candidate", 
                       "candidate is receiving an appendEntries, checking message term...");
                 if term >= self.log.last_term {
@@ -219,7 +219,7 @@ mod tests {
         let (candidate, _, _) = setup();
 
         let msg = Message {
-            event: Event::AppendEntries { index: 1, term: 2 },
+            event: Event::AppendEntries { term: 2, command: String::from("") },
             term: 2,
             to: Address::Broadcast,
             from: Address::Peer("c".into()),

--- a/src/raft/node/candidate.rs
+++ b/src/raft/node/candidate.rs
@@ -116,7 +116,7 @@ impl Role<Candidate> {
                 }
             },
             _ => { 
-                info!(target: "raft_candidate", "receiving undefined message event");
+                info!(target: "raft_candidate", "receiving another message event");
                 Ok(self.into()) 
             }
         }
@@ -135,6 +135,7 @@ impl Role<Candidate> {
                 1,
             );
 
+            // todo: fix this poor error handling
             if let Err(error) = self.node_tx.send(Message::new(
                 self.log.last_term,
                 Address::Peer(self.id.clone()),

--- a/src/raft/node/candidate.rs
+++ b/src/raft/node/candidate.rs
@@ -29,7 +29,7 @@ impl Candidate {
 impl Role<Candidate> {
     pub fn step(mut self, msg: Message) -> Result<Node, &'static str> {
         match msg.event {
-            Event::AppendEntries { entries: _, } => {
+            Event::AppendEntries { entries: _, commit_index: _ } => {
                 info!(target: "raft_candidate", 
                       "candidate is receiving an appendEntries, checking message term...");
                 if msg.term >= self.log.last_term {
@@ -219,7 +219,8 @@ mod tests {
 
         let msg = Message {
             event: Event::AppendEntries { 
-                entries: vec!(Entry { index: 1, term: 2, command: "".to_string()}) 
+                entries: Some(vec!(Entry { index: 1, term: 2, command: "".to_string()})),
+                commit_index: 0
             },
             term: 2,
             to: Address::Broadcast,

--- a/src/raft/node/candidate.rs
+++ b/src/raft/node/candidate.rs
@@ -1,5 +1,5 @@
 use super::super::{message::Address, message::Event, message::Message};
-use super::{follower::Follower, leader::Leader, Node, Role};
+use super::{follower::Follower, leader::Leader, Node, Role, log::Entry};
 use crate::utils::config::CONFIG;
 use rand::Rng;
 use log::info;
@@ -29,7 +29,7 @@ impl Candidate {
 impl Role<Candidate> {
     pub fn step(mut self, msg: Message) -> Result<Node, &'static str> {
         match msg.event {
-            Event::AppendEntries { entries: _, index: _ } => {
+            Event::AppendEntries { entries: _, } => {
                 info!(target: "raft_candidate", 
                       "candidate is receiving an appendEntries, checking message term...");
                 if msg.term >= self.log.last_term {
@@ -217,7 +217,9 @@ mod tests {
         let (candidate, _, _) = setup();
 
         let msg = Message {
-            event: Event::AppendEntries { index: 1, entries: vec!(String::from("")) },
+            event: Event::AppendEntries { 
+                entries: vec!(Entry { index: 1, term: 2, command: "".to_string()}) 
+            },
             term: 2,
             to: Address::Broadcast,
             from: Address::Peer("c".into()),

--- a/src/raft/node/candidate.rs
+++ b/src/raft/node/candidate.rs
@@ -101,7 +101,8 @@ impl Role<Candidate> {
                     info!(target: "raft_candidate", "candidate received a vote");
                     self.role.votes += 1;
 
-                    // todo: check this rule (i guess it can become leader with majority of votes instead of all votes)
+                    // todo: check this rule 
+                    // (i guess it can become leader with majority of votes instead of all votes)
                     if self.role.votes >= self.peers.len() as u64 {
                         let peers = self.peers.clone();
                         Ok(self
@@ -135,14 +136,18 @@ impl Role<Candidate> {
                 1,
             );
 
-            // todo: fix this poor error handling
-            if let Err(error) = self.node_tx.send(Message::new(
+            match self.node_tx.send(Message::new(
                 self.log.last_term,
                 Address::Peer(self.id.clone()),
                 Address::Broadcast,
                 Event::RequestVote {},
             )) {
-                panic!("{}", error);
+                Ok(..) => 
+                    info!(target: "raft_candidate", 
+                          "candidate sent the message successfully"),
+                Err(e) => 
+                    info!(target: "raft_candidate",
+                          "error when trying to send the message, error: {}", e)
             };
 
             self.into()

--- a/src/raft/node/follower.rs
+++ b/src/raft/node/follower.rs
@@ -226,4 +226,6 @@ mod tests {
             _ => panic!("Expected node to be follower"),
         }
     }
+
+    // todo: test follower appending log when receiving appendEntries
 }

--- a/src/raft/node/follower.rs
+++ b/src/raft/node/follower.rs
@@ -30,7 +30,7 @@ impl Role<Follower> {
         }
 
         match msg.event {
-            Event::AppendEntries { term, command: _ } => {
+            Event::AppendEntries { term, command: _, index: _ } => {
                 if self.is_leader(&msg.from) {
                     info!(target: "raft_follower", "receiving appendEntries from leader");
                     self.log.append(term, String::from(""));
@@ -194,7 +194,7 @@ mod tests {
         match node {
             Node::Follower(follower) => {
                 let msg = Message {
-                    event: Event::AppendEntries { term: 1, command: String::from("") },
+                    event: Event::AppendEntries { term: 1, index: 1, command: String::from("") },
                     term: 1,
                     to: Address::Peer("b".into()),
                     from: Address::Peer("a".into()),

--- a/src/raft/node/follower.rs
+++ b/src/raft/node/follower.rs
@@ -21,6 +21,7 @@ impl Follower {
     }
 }
 
+// todo: implement the AckEntries event
 impl Role<Follower> {
     pub fn step(mut self, msg: Message) -> Result<Node, &'static str> {
         info!(target: "raft_follower", "the follower is receiving a message from {:?}", &msg.from);

--- a/src/raft/node/follower.rs
+++ b/src/raft/node/follower.rs
@@ -1,5 +1,5 @@
 use super::super::{message::Address, message::Event, message::Message};
-use super::{candidate::Candidate, Node, Role};
+use super::{candidate::Candidate, Node, Role, log::Entry};
 use crate::utils::config::CONFIG;
 use log::info;
 
@@ -31,7 +31,7 @@ impl Role<Follower> {
         }
 
         match msg.event {
-            Event::AppendEntries { entries: _, index: _ } => {
+            Event::AppendEntries { entries: _ } => {
                 if self.is_leader(&msg.from) {
                     info!(target: "raft_follower", "receiving appendEntries from leader");
                     self.log.append(msg.term, vec!(String::from("")));
@@ -192,7 +192,11 @@ mod tests {
         match node {
             Node::Follower(follower) => {
                 let msg = Message {
-                    event: Event::AppendEntries { index: 1, entries: vec!(String::from("") )},
+                    event: Event::AppendEntries {
+                        entries: vec!(
+                            Entry { index: 1, term: 1, command: String::from("")}
+                        )
+                    },
                     term: 1,
                     to: Address::Peer("b".into()),
                     from: Address::Peer("a".into()),

--- a/src/raft/node/follower.rs
+++ b/src/raft/node/follower.rs
@@ -30,10 +30,10 @@ impl Role<Follower> {
         }
 
         match msg.event {
-            Event::AppendEntries { term, command: _, index: _ } => {
+            Event::AppendEntries { term, entries: _, index: _ } => {
                 if self.is_leader(&msg.from) {
                     info!(target: "raft_follower", "receiving appendEntries from leader");
-                    self.log.append(term, String::from(""));
+                    self.log.append(term, vec!(String::from("")));
                 }
             }
             Event::RequestVote { term } => {
@@ -194,7 +194,7 @@ mod tests {
         match node {
             Node::Follower(follower) => {
                 let msg = Message {
-                    event: Event::AppendEntries { term: 1, index: 1, command: String::from("") },
+                    event: Event::AppendEntries { term: 1, index: 1, entries: vec!(String::from("") )},
                     term: 1,
                     to: Address::Peer("b".into()),
                     from: Address::Peer("a".into()),

--- a/src/raft/node/follower.rs
+++ b/src/raft/node/follower.rs
@@ -78,7 +78,7 @@ impl Role<Follower> {
                         _ => panic!("Unexpected sender address"),
                     };
                 }
-            }
+            },
             Event::Vote { voted_for } => {
                 info!(target: "raft_follower", 
                       "follower is receiving a vote messge, term: {}, voted_for: {}, from: {:?}", 
@@ -200,14 +200,14 @@ mod tests {
 
     #[test]
     fn follower_step_reset_seen_ticks() {
-        let (follower, _, _) = setup();
+        let (follower, _node_rx, _) = setup();
 
         let node = follower.tick();
 
         match node {
             Node::Follower(follower) => {
                 let msg = Message {
-                    event: Event::Heartbeat {},
+                    event: Event::AppendEntries { entries: vec!() },
                     term: 1,
                     to: Address::Peer("b".into()),
                     from: Address::Peer("a".into()),

--- a/src/raft/node/follower.rs
+++ b/src/raft/node/follower.rs
@@ -1,5 +1,5 @@
 use super::super::{message::Address, message::Event, message::Message};
-use super::{candidate::Candidate, Node, Role, log::Entry};
+use super::{candidate::Candidate, Node, Role};
 use crate::utils::config::CONFIG;
 use log::info;
 

--- a/src/raft/node/follower.rs
+++ b/src/raft/node/follower.rs
@@ -30,10 +30,10 @@ impl Role<Follower> {
         }
 
         match msg.event {
-            Event::AppendEntries { index: _, term } => {
+            Event::AppendEntries { term, command: _ } => {
                 if self.is_leader(&msg.from) {
                     info!(target: "raft_follower", "receiving appendEntries from leader");
-                    self.log.append(term, None);
+                    self.log.append(term, String::from(""));
                 }
             }
             Event::RequestVote { term } => {
@@ -194,7 +194,7 @@ mod tests {
         match node {
             Node::Follower(follower) => {
                 let msg = Message {
-                    event: Event::AppendEntries { index: 1, term: 1 },
+                    event: Event::AppendEntries { term: 1, command: String::from("") },
                     term: 1,
                     to: Address::Peer("b".into()),
                     from: Address::Peer("a".into()),

--- a/src/raft/node/leader.rs
+++ b/src/raft/node/leader.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use log::info;
 
 pub struct Leader {
-    peer_last_index: HashMap<String, usize>,
+    pub peer_last_index: HashMap<String, usize>,
     idle_ticks: u64,
     idle_timeout: u64,
 }
@@ -51,7 +51,8 @@ impl Role<Leader> {
                         Event::AppendEntries{ entries: None, commit_index: self.log.commit_index }
                 )).unwrap();
             } else {
-                info!(target: "raft_leader", "leader is broadcasting appendEntries to update peers logs");
+                info!(target: "raft_leader", 
+                      "leader is broadcasting appendEntries to update peers logs");
                 let logs = self.log.entries.get(peer_last_index+0..).unwrap().to_vec();
                 info!(target: "raft_leader", "appendEntries logs: {:?}", logs);
                 self.node_tx.send(
@@ -91,7 +92,8 @@ impl Role<Leader> {
                 let replicated = self.role.peer_last_index
                     .iter()
                     .filter(|entry| entry.1 == &self.log.last_index).count();
-                info!(target: "raft_leader", "leader replicated index {} in {} peers", index, replicated);
+                info!(target: "raft_leader", 
+                      "leader replicated index {} in {} peers", index, replicated);
 
                 if replicated >= (self.peers.len()/2) &&
                     (self.log.last_index > self.log.commit_index) {

--- a/src/raft/node/leader.rs
+++ b/src/raft/node/leader.rs
@@ -96,6 +96,8 @@ impl Role<Leader> {
                     .filter(|entry| entry.1 == &self.log.last_index).count();
                 info!(target: "raft_leader", "leader replicated index {} in {} peers", index, replicated);
                 // todo: implement messaging to followers commit their local logs (Message::CommitEntries)
+                // this can be implemented using heartbeats or appendEntries containing a
+                // last_index field, then every follower must commit entries up to that index
                 if replicated >= (self.peers.len()/2) &&
                     (self.log.last_index > self.log.commit_index) {
                     info!(target: "raft_leader", "leader commiting safe replicated entries");
@@ -112,7 +114,6 @@ impl Role<Leader> {
                 let entry = Entry{ index: self.log.last_index+1, term: self.log.last_term, command };
                 self.log.append(vec!(entry));
                 
-                // todo: write test for this function call inside ClientRequest
                 let new_node = self.broadcast_append_entries();
                 return Ok(new_node.into())
             }

--- a/src/raft/node/leader.rs
+++ b/src/raft/node/leader.rs
@@ -1,8 +1,7 @@
 use super::{Node, Role};
-use super::super::{message::Message, message::Event, message::Query, message::Address::{Peer, Broadcast}};
+use super::super::{message::Message, message::Event, message::Address::{Peer, Broadcast}};
 use std::collections::HashMap;
 use log::info;
-use ron::ser::to_string_pretty;
 
 pub struct Leader {
     peer_last_index: HashMap<String, u64>,
@@ -40,6 +39,16 @@ impl Role<Leader> {
         }
     }
 
+    // once a leader has been elected, it begins servicing
+    // client requests. Each client request contains a command to
+    // be executed by the replicated state machines.
+    //
+    // the leader appends the command to its log as a new entry, 
+    // then issues AppendEntries RPCs in parallel to each of the other
+    // servers to replicate the entry. When the entry has been
+    // safely replicated (as described below), the leader applies
+    // the entry to its state machine and returns the result of that
+    // execution to the client.
     pub fn step(self, msg: Message) -> Result<Node, &'static str> {
         // let _ = self.node_tx.send(Message::new(1, Broadcast, Broadcast, AppendEntries{term:1,index:1}));
         // TODO: implement leader message handling

--- a/src/raft/node/leader.rs
+++ b/src/raft/node/leader.rs
@@ -224,7 +224,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_leader_broadcast_append_entries_1() {
+    async fn leader_broadcast_append_entries_1() {
         let (mut leader, mut node_rx, _) = setup();
 
         leader.role.peer_last_index.clear();
@@ -264,7 +264,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_leader_broadcast_append_entries_2() {
+    async fn leader_broadcast_append_entries_2() {
         let (mut leader, mut node_rx, _) = setup();
 
         leader.role.peer_last_index.clear();
@@ -309,7 +309,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_leader_append_entries_with_commit_index() {
+    async fn leader_append_entries_with_commit_index() {
         let (mut leader, mut node_rx, _) = setup();
         leader.log.commit_index = 2;
         leader.tick().tick().tick().tick();

--- a/src/raft/node/leader.rs
+++ b/src/raft/node/leader.rs
@@ -48,9 +48,7 @@ impl Role<Leader> {
                 self.log.last_term,
                 Peer(self.id.clone()),
                 Broadcast,
-                Event::Heartbeat {
-                    term: self.log.last_term
-                }
+                Event::Heartbeat {}
         )).unwrap();
 
         self.into()
@@ -61,13 +59,13 @@ impl Role<Leader> {
             Event::AppendEntries { .. } => {
                 info!(target: "raft_leader", "leader receiving an AppendEntries");
             }
-            Event::Vote { term: _, voted_for: _ } => {
+            Event::Vote { voted_for: _ } => {
                 info!(target: "raft_leader", "leader receiving an Vote");
             }
-            Event::RequestVote { term: _ } => {
+            Event::RequestVote {} => {
                 info!(target: "raft_leader", "leader receiving an RequestVote");
             }
-            Event::Heartbeat { term: _ } => {
+            Event::Heartbeat {} => {
                 info!(target: "raft_leader", "leader receiving an Heartbeat");
             }
             Event::AckEntries { index } => {
@@ -92,7 +90,6 @@ impl Role<Leader> {
                     Peer(self.id.clone()),
                     Broadcast,
                     Event::AppendEntries { 
-                        term: self.log.last_term, 
                         index: self.log.last_index, 
                         entries: vec!(command.clone())
                     }
@@ -161,7 +158,7 @@ mod test {
                };
 
                match event {
-                   Event::Heartbeat { term, .. } => { assert_eq!(term, 0) }
+                   Event::Heartbeat {} => { assert_eq!(term, 0) }
                    _ => panic!("Expected event to be an AppendEntries")
                };
            }

--- a/src/raft/node/leader.rs
+++ b/src/raft/node/leader.rs
@@ -308,6 +308,18 @@ mod test {
         };
     }
 
-    // todo: write a test where the leader commits entries, and sends appendEntries with the updated
-    // commit_index
+    #[tokio::test]
+    async fn test_leader_append_entries_with_commit_index() {
+        let (mut leader, mut node_rx, _) = setup();
+        leader.log.commit_index = 2;
+        leader.tick().tick().tick().tick();
+
+        let append_entries_msg = node_rx.recv().await.unwrap();
+        match append_entries_msg.event {
+            Event::AppendEntries { entries: _, commit_index } => {
+                assert_eq!(commit_index, 2);
+            },
+            _ => panic!("Excpected event to be an AppendEntries")
+        }
+    }
 }

--- a/src/raft/node/leader.rs
+++ b/src/raft/node/leader.rs
@@ -48,7 +48,7 @@ impl Role<Leader> {
                         self.log.last_term,
                         Peer(self.id.clone()),
                         Peer(String::from(peer)),
-                        Event::AppendEntries{ entries: Some(vec!()), commit_index: self.log.commit_index }
+                        Event::AppendEntries{ entries: None, commit_index: self.log.commit_index }
                 )).unwrap();
             } else {
                 info!(target: "raft_leader", "leader is broadcasting appendEntries to update peers logs");

--- a/src/raft/node/log.rs
+++ b/src/raft/node/log.rs
@@ -1,0 +1,50 @@
+pub enum Command {
+    Get,
+    Set
+}
+
+pub struct Entry {
+    index: u64,
+    term: u64,
+    command: Option<Command>,
+}
+
+pub struct Log {
+    pub last_index: u64,
+    pub last_term: u64,
+    pub commit_index: u64,
+    pub commit_term: u64,
+    pub entries: Vec<Entry>,
+}
+
+impl Log {
+    pub fn new() -> Self {
+        Self {
+            last_index: 0,
+            last_term: 0,
+            commit_index: 0,
+            commit_term: 0,
+            entries: <Vec<Entry>>::default(),
+        }
+    }
+
+    pub fn append(&mut self, term: u64, command: Option<Command>) {
+        let entry = Entry {
+            index: self.last_index + 1,
+            term,
+            command,
+        };
+
+        self.last_index += 1;
+        self.last_term = term;
+        self.entries.push(entry);
+    }
+
+    // TODO
+    //
+    // an entry is considered committed if it is safe for that
+    // entry to be applied to state machines
+    // pub fn commit(mut self, entry: Entry) {
+    //
+    // }
+}

--- a/src/raft/node/log.rs
+++ b/src/raft/node/log.rs
@@ -26,17 +26,11 @@ impl Log {
         }
     }
 
-    pub fn append(&mut self, term: u64, entries: Vec<String>) {
-        let _ = entries.iter().for_each(|command| {
-            let entry = Entry {
-                index: self.last_index + 1,
-                term,
-                command: command.to_string(),
-            };
-
-            self.last_index += 1;
-            self.last_term = term;
-            self.entries.push(entry);
+    pub fn append(&mut self, entries: Vec<Entry>) {
+        entries.iter().for_each(|entry| {
+            self.last_index = entry.index;
+            self.last_term = entry.term;
+            self.entries.push(entry.clone());
         });
     }
 }

--- a/src/raft/node/log.rs
+++ b/src/raft/node/log.rs
@@ -1,12 +1,10 @@
-pub enum Command {
-    Get,
-    Set
-}
+use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Entry {
     index: u64,
     term: u64,
-    command: Option<Command>,
+    command: String,
 }
 
 pub struct Log {
@@ -28,7 +26,7 @@ impl Log {
         }
     }
 
-    pub fn append(&mut self, term: u64, command: Option<Command>) {
+    pub fn append(&mut self, term: u64, command: String) {
         let entry = Entry {
             index: self.last_index + 1,
             term,

--- a/src/raft/node/log.rs
+++ b/src/raft/node/log.rs
@@ -26,16 +26,18 @@ impl Log {
         }
     }
 
-    pub fn append(&mut self, term: u64, command: String) {
-        let entry = Entry {
-            index: self.last_index + 1,
-            term,
-            command,
-        };
+    pub fn append(&mut self, term: u64, entries: Vec<String>) {
+        let _ = entries.iter().for_each(|command| {
+            let entry = Entry {
+                index: self.last_index + 1,
+                term,
+                command: command.to_string(),
+            };
 
-        self.last_index += 1;
-        self.last_term = term;
-        self.entries.push(entry);
+            self.last_index += 1;
+            self.last_term = term;
+            self.entries.push(entry);
+        });
     }
 
     // TODO

--- a/src/raft/node/log.rs
+++ b/src/raft/node/log.rs
@@ -1,16 +1,16 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Entry {
-    index: u64,
-    term: u64,
-    command: String,
+    pub index: usize,
+    pub term: u64,
+    pub command: String,
 }
 
 pub struct Log {
-    pub last_index: u64,
+    pub last_index: usize,
     pub last_term: u64,
-    pub commit_index: u64,
+    pub commit_index: usize,
     pub commit_term: u64,
     pub entries: Vec<Entry>,
 }

--- a/src/raft/node/log.rs
+++ b/src/raft/node/log.rs
@@ -42,4 +42,27 @@ impl Log {
     }
 }
 
-// todo: write tests
+mod test {
+    use super::*;
+
+    #[test]
+    fn new_log() {
+        let log = Log::new();
+        assert_eq!(log.last_index, 0);
+        assert_eq!(log.last_term, 0);
+        assert_eq!(log.entries.len(), 0);
+    }
+
+    #[test]
+    fn log_append() {
+        let mut log = Log::new();
+        log.append(vec!(Entry {
+            index: 1,
+            term: 0,
+            command: "a".to_string()
+        }));
+        assert_eq!(log.last_index, 1);
+        assert_eq!(log.entries.len(), 1);
+        assert_eq!(log.entries[0].command, "a");
+    }
+}

--- a/src/raft/node/log.rs
+++ b/src/raft/node/log.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use log::info;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Entry {
@@ -11,7 +12,7 @@ pub struct Log {
     pub last_index: usize,
     pub last_term: u64,
     pub commit_index: usize,
-    pub commit_term: u64,
+    // pub commit_term: u64,
     pub entries: Vec<Entry>,
 }
 
@@ -21,7 +22,7 @@ impl Log {
             last_index: 0,
             last_term: 0,
             commit_index: 0,
-            commit_term: 0,
+            // commit_term: 0,
             entries: <Vec<Entry>>::default(),
         }
     }
@@ -32,6 +33,12 @@ impl Log {
             self.last_term = entry.term;
             self.entries.push(entry.clone());
         });
+    }
+
+    // todo: implement commit function
+    pub fn commit(&mut self, index: usize) {
+        self.commit_index = index;
+        info!("commiting index: {}", index);
     }
 }
 

--- a/src/raft/node/log.rs
+++ b/src/raft/node/log.rs
@@ -39,12 +39,6 @@ impl Log {
             self.entries.push(entry);
         });
     }
-
-    // TODO
-    //
-    // an entry is considered committed if it is safe for that
-    // entry to be applied to state machines
-    // pub fn commit(mut self, entry: Entry) {
-    //
-    // }
 }
+
+// todo: write tests

--- a/src/raft/node/mod.rs
+++ b/src/raft/node/mod.rs
@@ -4,9 +4,9 @@ use crate::utils::config::CONFIG;
 use tokio::sync::mpsc;
 use self::log::Log;
 
-mod candidate;
-mod follower;
-mod leader;
+pub mod candidate;
+pub mod follower;
+pub mod leader;
 pub mod log;
 
 pub enum Node {
@@ -60,13 +60,14 @@ impl Node {
     }
 }
 
+// todo: remove pub fields and export a constructor (new::)
 pub struct Role<T> {
-    id: String,
-    peers: Vec<String>,
-    log: Log,
-    role: T,
-    node_tx: mpsc::UnboundedSender<Message>,
-    state_tx: mpsc::UnboundedSender<Instruction>,
+    pub id: String,
+    pub peers: Vec<String>,
+    pub log: Log,
+    pub role: T,
+    pub node_tx: mpsc::UnboundedSender<Message>,
+    pub state_tx: mpsc::UnboundedSender<Instruction>,
 }
 
 impl<R> Role<R> {

--- a/src/raft/node/mod.rs
+++ b/src/raft/node/mod.rs
@@ -1,5 +1,5 @@
 use super::message::Message;
-use super::state_machine::{Instruction, StateDriver};
+use super::state_machine::{Instruction, StateMachine};
 use crate::utils::config::CONFIG;
 use tokio::sync::mpsc;
 use self::log::Log;
@@ -22,10 +22,10 @@ impl Node {
         log: Log,
         node_tx: mpsc::UnboundedSender<Message>,
     ) -> Self {
+        // spawn state_machine task
         let (state_tx, state_rx) = tokio::sync::mpsc::unbounded_channel();
-
-        let driver = StateDriver::new(state_rx, node_tx.clone());
-        tokio::spawn(driver.run());
+        let state_machine = StateMachine::new(state_rx, node_tx.clone());
+        tokio::spawn(state_machine.run());
 
         let node = Role::<follower::Follower> {
             id: id.to_string(),

--- a/src/raft/node/mod.rs
+++ b/src/raft/node/mod.rs
@@ -2,53 +2,12 @@ use super::message::Message;
 use super::state_machine::{Instruction, StateDriver};
 use crate::utils::config::CONFIG;
 use tokio::sync::mpsc;
+use log::Log;
 
 mod candidate;
 mod follower;
 mod leader;
-
-pub struct Entry {
-    index: u64,
-    term: u64,
-    command: Option<Vec<u8>>,
-}
-
-pub struct Log {
-    last_index: u64,
-    last_term: u64,
-    commit_index: u64,
-    commit_term: u64,
-    entries: Vec<Entry>,
-}
-
-impl Log {
-    pub fn new() -> Self {
-        Self {
-            last_index: 0,
-            last_term: 0,
-            commit_index: 0,
-            commit_term: 0,
-            entries: <Vec<Entry>>::default(),
-        }
-    }
-
-    pub fn append(&mut self, term: u64, command: Option<Vec<u8>>) {
-        let entry = Entry {
-            index: self.last_index + 1,
-            term,
-            command,
-        };
-
-        self.last_index += 1;
-        self.last_term = term;
-        self.entries.push(entry);
-    }
-
-    // TODO: commit log (and implement log replication)
-    // pub fn commit(mut self, entry: Entry) {
-    //
-    // }
-}
+pub mod log;
 
 pub enum Node {
     Follower(Role<follower::Follower>),

--- a/src/raft/node/mod.rs
+++ b/src/raft/node/mod.rs
@@ -22,7 +22,6 @@ impl Node {
         log: Log,
         node_tx: mpsc::UnboundedSender<Message>,
     ) -> Self {
-        // spawn state_machine task
         let (state_tx, state_rx) = tokio::sync::mpsc::unbounded_channel();
         let state_machine = StateMachine::new(state_rx, node_tx.clone());
         tokio::spawn(state_machine.run());

--- a/src/raft/node/mod.rs
+++ b/src/raft/node/mod.rs
@@ -2,7 +2,7 @@ use super::message::Message;
 use super::state_machine::{Instruction, StateDriver};
 use crate::utils::config::CONFIG;
 use tokio::sync::mpsc;
-use log::Log;
+use self::log::Log;
 
 mod candidate;
 mod follower;

--- a/src/raft/server.rs
+++ b/src/raft/server.rs
@@ -2,6 +2,7 @@ use super::{
     message,
     message::Address::{Broadcast, Peer},
     node,
+    node::log::Log
 };
 use crate::utils::config::CONFIG;
 use std::io::prelude::*;
@@ -21,7 +22,7 @@ pub struct Server {
 
 // raft server layer to handle peer networking (incoming and sending tcp messages)
 impl Server {
-    pub async fn new(id: &str, peers: Vec<String>, log: node::Log) -> Self {
+    pub async fn new(id: &str, peers: Vec<String>, log: Log) -> Self {
         let (node_tx, node_rx) = unbounded_channel();
         info!(target: "raft", "raft server starting");
         Self {

--- a/src/raft/server.rs
+++ b/src/raft/server.rs
@@ -20,7 +20,6 @@ pub struct Server {
     node_rx: UnboundedReceiver<message::Message>,
 }
 
-// raft server layer to handle peer networking (incoming and sending tcp messages)
 impl Server {
     pub async fn new(id: &str, peers: Vec<String>, log: Log) -> Self {
         let (node_tx, node_rx) = unbounded_channel();
@@ -32,8 +31,6 @@ impl Server {
         }
     }
 
-    // TODO: use hashtables to only send messages to valid peers, 
-    // blocking "external message injection"
     pub async fn serve(self, tcp_listener: TcpListener) -> Result<(), &'static str> {
         let (tcp_inbound_tx, tcp_inbound_rx) = unbounded_channel::<message::Message>();
         tokio::spawn(Self::receiving_tcp(tcp_listener, tcp_inbound_tx));
@@ -41,9 +38,6 @@ impl Server {
         Self::event_loop(self.node, tcp_inbound_rx, CONFIG.raft.tick_millis_duration).await
     }
 
-    // event loop handles 2 tasks: 
-    // - node ticks
-    // - node receiving messages
     async fn event_loop(
         mut node: node::Node,
         tcp_inbound_rx: UnboundedReceiver<message::Message>,
@@ -60,7 +54,6 @@ impl Server {
         }
     }
 
-    // receiving messages
     async fn receiving_tcp(
         listener: TcpListener,
         tcp_inbound_tr: UnboundedSender<message::Message>,
@@ -85,7 +78,8 @@ impl Server {
                         panic!("message incorrect");
                     };
 
-                    // example payload: "(term:1,from:Broadcast,to:Broadcast,event:AppendEntries(index:1,term:1))"
+                    // example payload: 
+                    // "(term:1,from:Broadcast,to:Broadcast,event:AppendEntries(index:1,term:1))"
                     let parsed_msg: message::Message = ron::from_str(req_body[1]).unwrap();
                     tcp_tr.send(parsed_msg).unwrap();
 
@@ -102,7 +96,6 @@ impl Server {
         Ok(())
     }
 
-    // sending messages to peers
     async fn sending_tcp(
         node_rx: UnboundedReceiver<message::Message>,
         peers: Vec<String>,

--- a/src/raft/state_machine.rs
+++ b/src/raft/state_machine.rs
@@ -7,7 +7,7 @@ use log::info;
 // todo: update the command data structure
 #[derive(Debug)]
 pub struct Instruction {
-    pub index: u64,
+    pub index: usize,
     pub term: u64,
     pub command: String,
 }
@@ -15,7 +15,7 @@ pub struct Instruction {
 pub struct StateMachine {
     state_rx: UnboundedReceiverStream<Instruction>,
     node_tx: UnboundedSender<Message>,
-    applied_index: u64,
+    applied_index: usize,
 }
 
 impl StateMachine {

--- a/src/raft/state_machine.rs
+++ b/src/raft/state_machine.rs
@@ -1,31 +1,23 @@
-use super::message::{Address, Message};
+use super::message::Message;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_stream::StreamExt as _;
 use log::info;
 
-#[derive(Clone, Debug)]
-pub struct Entry {
+#[derive(Debug)]
+pub struct Instruction {
     pub index: u64,
     pub term: u64,
-    pub command: Option<Vec<u8>>,
+    pub command: String,
 }
 
-#[derive(Debug)]
-pub enum Instruction {
-    Abort,
-    Append { entry: Entry },
-    Notify { id: Vec<u8>, address: Address },
-    Vote { term: u64, address: Address },
-}
-
-pub struct StateDriver {
+pub struct StateMachine {
     state_rx: UnboundedReceiverStream<Instruction>,
     node_tx: UnboundedSender<Message>,
     applied_index: u64,
 }
 
-impl StateDriver {
+impl StateMachine {
     pub fn new(
         state_rx: UnboundedReceiver<Instruction>,
         node_tx: UnboundedSender<Message>,
@@ -43,6 +35,13 @@ impl StateDriver {
         while let Some(msg) = self.state_rx.next().await {
             println!("\nInstruction received by state_driver:");
             println!("{:?}", msg);
+
+            // execute command 
+            
+            // commit index 
+            self.applied_index = msg.index;
+
+            // return response
         }
     }
 }

--- a/src/raft/state_machine.rs
+++ b/src/raft/state_machine.rs
@@ -4,6 +4,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_stream::StreamExt as _;
 use log::info;
 
+// todo: update the command data structure
 #[derive(Debug)]
 pub struct Instruction {
     pub index: u64,
@@ -36,12 +37,11 @@ impl StateMachine {
             println!("\nInstruction received by state_driver:");
             println!("{:?}", msg);
 
-            // execute command 
+            // todo: execute command 
             
-            // commit index 
             self.applied_index = msg.index;
 
-            // return response
+            // todo: return response
         }
     }
 }

--- a/tests/raft_election_tests.rs
+++ b/tests/raft_election_tests.rs
@@ -1,0 +1,70 @@
+use alexandria::raft::{node::Node, node::log::Log, message::Event};
+use tokio::sync::mpsc::unbounded_channel;
+
+#[tokio::test]
+async fn raft_basic_election() {
+    let (node_tx_1, mut node_rx_1) = unbounded_channel();
+    let node1 = Node::new(
+        "a",
+        vec!("b".to_string(), "c".to_string()),
+        Log::new(),
+        node_tx_1
+        ).await;
+
+    let (node_tx_2, mut node_rx_2) = unbounded_channel();
+    let node2 = Node::new(
+        "b",
+        vec!("a".to_string(), "c".to_string()),
+        Log::new(),
+        node_tx_2
+        ).await;
+
+    let (node_tx_3, mut node_rx_3) = unbounded_channel();
+    let node3 = Node::new(
+        "c",
+        vec!("a".to_string(), "b".to_string()),
+        Log::new(),
+        node_tx_3
+        ).await;
+
+    // node1 should broadcast request_vote messages
+    let node1 = node1.tick().tick().tick().tick().tick();
+    let _request_vote_msg = node_rx_1.recv().await.unwrap();
+
+    // node1 should broadcast a requestVote
+    match _request_vote_msg.event {
+        Event::RequestVote{} => {},
+        _ => panic!("Expected event to be RequestVote")
+    };
+
+    // node2 should receive and reply with a vote
+    node2.step(_request_vote_msg.clone()).unwrap();
+    let _vote_msg_2 = node_rx_2.recv().await.unwrap();
+
+    // node2 should vote for peer "a"
+    match _vote_msg_2.clone().event {
+        Event::Vote{ voted_for } => {
+            assert_eq!(voted_for, "a");
+        },
+        _ => panic!("Expected event to be Vote")
+    }
+
+    // node3 should receive and reply with a vote
+    node3.step(_request_vote_msg).unwrap();
+    let _vote_msg_3 = node_rx_3.recv().await.unwrap();
+
+    // node3 should vote for peer "a"
+    match _vote_msg_3.clone().event {
+        Event::Vote{ voted_for } => {
+            assert_eq!(voted_for, "a");
+        },
+        _ => panic!("Expected event to be Vote")
+    }
+
+    // node1 should recive the votes and became the leader
+    let node1 = node1.step(_vote_msg_2).unwrap().step(_vote_msg_3).unwrap();
+    match node1 {
+        Node::Leader(_) => {},
+        _ => panic!("Expected node1 to be the leader")
+    }
+}

--- a/tests/raft_log_replication_tests.rs
+++ b/tests/raft_log_replication_tests.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc::unbounded_channel;
 #[tokio::test] 
 async fn raft_basic_log_replication() {
     let (node_tx_1, mut node_rx_1) = tokio::sync::mpsc::unbounded_channel();
-    let (state_tx_1, state_rx_1) = tokio::sync::mpsc::unbounded_channel();
+    let (state_tx_1, _) = tokio::sync::mpsc::unbounded_channel();
     let peers_1 = vec!["b".into(), "c".into()];
     let leader = Role {
         id: "a".into(),
@@ -20,7 +20,7 @@ async fn raft_basic_log_replication() {
     };
 
     let (node_tx_2, mut node_rx_2) = unbounded_channel();
-    let (state_tx_2, state_rx_2) = tokio::sync::mpsc::unbounded_channel();
+    let (state_tx_2, _) = tokio::sync::mpsc::unbounded_channel();
     let node2 = Role {
         id: "b".into(),
         peers: vec!["a".into(), "c".into()],
@@ -31,7 +31,7 @@ async fn raft_basic_log_replication() {
     };
 
     let (node_tx_3, mut node_rx_3) = unbounded_channel();
-    let (state_tx_3, state_rx_3) = tokio::sync::mpsc::unbounded_channel();
+    let (state_tx_3, _) = tokio::sync::mpsc::unbounded_channel();
     let node3 = Role {
         id: "c".into(),
         peers: vec!["a".into(), "b".into()],
@@ -48,8 +48,9 @@ async fn raft_basic_log_replication() {
         to: Address::Peer("l".to_string()),
         from: Address::Peer("".into()),
     };
-    let leader = leader.step(client_request);
+    let leader = leader.step(client_request).unwrap();
     // then leader should broadcast_append_entries to replicate log entry on peers
+    let _ = node_rx_1.recv().await.unwrap();
     let append_entries_msg = node_rx_1.recv().await.unwrap();
     match append_entries_msg.clone().event {
         Event::AppendEntries { entries, commit_index: _ } => {
@@ -65,7 +66,18 @@ async fn raft_basic_log_replication() {
     };
 
     // node2 should process the appendEntries and reply with a AckEntries message
-    let node2 = node2.step(append_entries_msg.clone());
+    let node2 = node2.step(append_entries_msg.clone()).unwrap();
+    let node2 = match node2 {
+        Node::Follower(follower) => {
+            assert_eq!(follower.log.last_index, 1);
+            assert_eq!(follower.log.commit_index, 0);
+            assert_eq!(follower.log.entries[0].index, 1);
+            assert_eq!(follower.log.entries[0].command, "command-test-1");
+            follower
+        },
+        _ => panic!("expected node2 to be follower")
+        
+    };
     let ack_entries_msg_2 = node_rx_2.recv().await.unwrap();
     match ack_entries_msg_2.event {
         Event::AckEntries {index} => {
@@ -75,7 +87,18 @@ async fn raft_basic_log_replication() {
     }
     
     // node3 should process the appendEntries and reply with a AckEntries message
-    let node3 = node3.step(append_entries_msg);
+    let node3 = node3.step(append_entries_msg).unwrap();
+    let node3 = match node3 {
+        Node::Follower(follower) => {
+            assert_eq!(follower.log.last_index, 1);
+            assert_eq!(follower.log.commit_index, 0);
+            assert_eq!(follower.log.entries[0].index, 1);
+            assert_eq!(follower.log.entries[0].command, "command-test-1");
+            follower
+        },
+        _ => panic!("expected node2 to be follower")
+        
+    };
     let ack_entries_msg_3 = node_rx_3.recv().await.unwrap();
     match ack_entries_msg_3.event {
         Event::AckEntries {index} => {
@@ -84,8 +107,38 @@ async fn raft_basic_log_replication() {
         _ => panic!("Expected message event to be AckEntries")
     }
 
-    // todo:
-    // after receiving the ackEntries from nodes, leader must commit the log entry, 
-    // and send commitEntries with the new commit_index,
-    // the nodes should commit the entries as well
+    let leader = leader.step(ack_entries_msg_2).unwrap();
+    let leader = match leader {
+        Node::Leader(leader) => {
+            assert_eq!(leader.role.peer_last_index.get("b"), Some(1).as_ref());
+            // peer c has not acknowledged yet, so the index is 0
+            assert_eq!(leader.role.peer_last_index.get("c"), Some(0).as_ref());
+            // leader has commited the new entry since it 
+            // replicated in 2 peers from a total of 3 peers
+            assert_eq!(leader.log.commit_index, 1);
+            leader
+        },
+        _ => panic!("Expected node to be leader")
+    };
+
+    let _leader = leader.tick().tick().tick().tick();
+    // now in the next leader appendEntries, he will include the new commit_index
+    let commit_replication_msg = node_rx_1.recv().await.unwrap();
+    match commit_replication_msg.clone().event {
+        Event::AppendEntries { entries: _, commit_index } => {
+            assert_eq!(commit_index, 1);
+        },
+        _ => panic!("Expected message event to be AppendEntries")
+    };
+
+    // when node2 receive the appendEntries with the new commit_index, 
+    // the node will commit to the same index
+    assert_eq!(node2.log.commit_index, 0);
+    let node2 = node2.step(commit_replication_msg).unwrap();
+    match node2 {
+        Node::Follower(follower) => {
+            assert_eq!(follower.log.commit_index, 1);
+        },
+        _ => panic!("Expected node to be follower")
+    };
 }

--- a/tests/raft_log_replication_tests.rs
+++ b/tests/raft_log_replication_tests.rs
@@ -52,9 +52,14 @@ async fn raft_basic_log_replication() {
     // then leader should broadcast_append_entries to replicate log entry on peers
     let append_entries_msg = node_rx_1.recv().await.unwrap();
     match append_entries_msg.clone().event {
-        Event::AppendEntries {entries} => {
-            assert_eq!(entries[0].index, 1);
-            assert_eq!(entries[0].command, "command-test-1");
+        Event::AppendEntries { entries, commit_index: _ } => {
+            match entries {
+                Some(entries) => {
+                    assert_eq!(entries[0].index, 1);
+                    assert_eq!(entries[0].command, "command-test-1");
+                },
+                None => panic!("appendEntries should contain entries")
+            }
         },
         _ => panic!("Expected message event to be AppendEntries")
     };
@@ -79,6 +84,8 @@ async fn raft_basic_log_replication() {
         _ => panic!("Expected message event to be AckEntries")
     }
 
-    // after receiving the ackEntries from nodes, leader must commit the log entry
-    // todo: how to handle the commit step? should the leader send and appendCommitEntries?
+    // todo:
+    // after receiving the ackEntries from nodes, leader must commit the log entry, 
+    // and send commitEntries with the new commit_index,
+    // the nodes should commit the entries as well
 }

--- a/tests/raft_log_replication_tests.rs
+++ b/tests/raft_log_replication_tests.rs
@@ -1,0 +1,84 @@
+use alexandria::raft::{
+    node::log::Log, node::Role, node::Node, node::leader::Leader, 
+    node::follower::Follower,
+    message::Message, message::Event, message::Address
+};
+use tokio::sync::mpsc::unbounded_channel;
+
+#[tokio::test] 
+async fn raft_basic_log_replication() {
+    let (node_tx_1, mut node_rx_1) = tokio::sync::mpsc::unbounded_channel();
+    let (state_tx_1, state_rx_1) = tokio::sync::mpsc::unbounded_channel();
+    let peers_1 = vec!["b".into(), "c".into()];
+    let leader = Role {
+        id: "a".into(),
+        peers: peers_1.clone(),
+        log: Log::new(),
+        node_tx: node_tx_1,
+        state_tx: state_tx_1,
+        role: Leader::new(peers_1, 2),
+    };
+
+    let (node_tx_2, mut node_rx_2) = unbounded_channel();
+    let (state_tx_2, state_rx_2) = tokio::sync::mpsc::unbounded_channel();
+    let node2 = Role {
+        id: "b".into(),
+        peers: vec!["a".into(), "c".into()],
+        log: Log::new(),
+        node_tx: node_tx_2,
+        state_tx: state_tx_2,
+        role: Follower::new(Some("a".to_string()), None, 4)
+    };
+
+    let (node_tx_3, mut node_rx_3) = unbounded_channel();
+    let (state_tx_3, state_rx_3) = tokio::sync::mpsc::unbounded_channel();
+    let node3 = Role {
+        id: "c".into(),
+        peers: vec!["a".into(), "b".into()],
+        log: Log::new(),
+        node_tx: node_tx_3,
+        state_tx: state_tx_3,
+        role: Follower::new(Some("a".to_string()), None, 4)
+    };
+
+    // leader should handle a clientRequest
+    let client_request = Message {
+        event: Event::ClientRequest { command: String::from("command-test-1") },
+        term: 1,
+        to: Address::Peer("l".to_string()),
+        from: Address::Peer("".into()),
+    };
+    let leader = leader.step(client_request);
+    // then leader should broadcast_append_entries to replicate log entry on peers
+    let append_entries_msg = node_rx_1.recv().await.unwrap();
+    match append_entries_msg.clone().event {
+        Event::AppendEntries {entries} => {
+            assert_eq!(entries[0].index, 1);
+            assert_eq!(entries[0].command, "command-test-1");
+        },
+        _ => panic!("Expected message event to be AppendEntries")
+    };
+
+    // node2 should process the appendEntries and reply with a AckEntries message
+    let node2 = node2.step(append_entries_msg.clone());
+    let ack_entries_msg_2 = node_rx_2.recv().await.unwrap();
+    match ack_entries_msg_2.event {
+        Event::AckEntries {index} => {
+            assert_eq!(index, 1);
+        },
+        _ => panic!("Expected message event to be AckEntries")
+    }
+    
+    // node3 should process the appendEntries and reply with a AckEntries message
+    let node3 = node3.step(append_entries_msg);
+    let ack_entries_msg_3 = node_rx_3.recv().await.unwrap();
+    match ack_entries_msg_3.event {
+        Event::AckEntries {index} => {
+            assert_eq!(index, 1);
+        },
+        _ => panic!("Expected message event to be AckEntries")
+    }
+
+    // after receiving the ackEntries from nodes, leader must commit the log entry
+    // todo: how to handle the commit step? should the leader send and appendCommitEntries?
+}


### PR DESCRIPTION
The main goal of this PR is to implement the log replication of Raft algorithm

some stuff this PR adds:
- leader handling clientRequests
- leader broadcasting new entries
- followers appending the entries and updating local logs
- followers sending ack append entries messages to leaders
- leader decides when to commit safe replicated entries
- some unit and integration tests
- other minor fixes